### PR TITLE
Added docker-compose compatibility without the need of a Dockerfile

### DIFF
--- a/ECCM.html
+++ b/ECCM.html
@@ -232,6 +232,7 @@ html.theme-bright .speed-menu select{  background:#fff;  color:#111;  border-col
   <h1>Ethernet Cable Connection Manager</h1>
   <span class="badge">1.0.5</span>
   <div style="margin-left:auto;display:flex;gap:8px">
+	<button id="btnSaveConfig" class="btn">Save</button>
 	<button id="btnSettings" class="btn">Settings</button>
     <button id="printSheet">Print layout</button>
   </div>
@@ -462,8 +463,17 @@ html.theme-bright .speed-menu select{  background:#fff;  color:#111;  border-col
   </div>
 </div>
 
+<script type="module">
+import config from '../data/config.json' with { type: 'json' };
 
-<script>
+// store as a string (localStorage only stores strings)
+localStorage.setItem('ethcm_profiles_v1', JSON.stringify(config));
+
+// (optional) verify
+console.log('saved config:', JSON.parse(localStorage.getItem('ethcm_profiles_v1')));
+</script>
+
+<script type="module">
 /* ===================== HIGHLIGHT TUNING ===================== */
 const HI_OUTLINE = 0; // px: outer white ring 
 const HI_RING    = 5; // px: inner white ring thickness
@@ -2437,6 +2447,30 @@ document.getElementById('importProfileFile').addEventListener('change', function
     finally{ e.target.value=''; }
   };
   reader.readAsText(file);
+});
+
+/* ===================== SAVE FULL CONFIG TO DATA ===================== */
+document.getElementById('btnSaveConfig').addEventListener('click', async () => {
+  try {
+    // Get your config from localStorage (or build it however you want)
+    const configText = localStorage.getItem('ethcm_profiles_v1') ?? '{}';
+    const configObj = JSON.parse(configText);
+
+    const res = await fetch('/api/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(configObj),
+    });
+
+    if (!res.ok) {
+      const msg = await res.text();
+      throw new Error(`PUT /api/config failed: ${res.status} ${msg}`);
+    }
+
+    console.log('Config saved to server (config.json overwritten).');
+  } catch (err) {
+    console.error('Save failed:', err);
+  }
 });
 
 /* ===================== BACKUP / RESTORE (all profiles) ===================== */

--- a/data/config.json
+++ b/data/config.json
@@ -1,0 +1,18 @@
+{
+  "current": "Default",
+  "profiles": {
+    "Default": {
+      "devices": [],
+      "links": [],
+      "portAliases": {},
+      "reservedPorts": {},
+      "portSpeeds": {},
+      "portVlans": {},
+      "portLinkedTo": {}
+    }
+  },
+  "settings": {
+    "maxPorts": 512,
+    "enablePortRename": false
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  web:
+    image: node:20-alpine
+    working_dir: /app/docker
+    ports:
+      - "3035:3035"
+    volumes:
+      - ./:/app
+    command: sh -c "npm install && node app.js"

--- a/docker/app.js
+++ b/docker/app.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const path = require('path');
+const fs = require('fs/promises');
+
+const app = express();
+const port = 3035;
+
+app.use(express.json()); // required to read req.body
+
+app.use('/data', express.static(path.join(__dirname, '..', 'data')));
+
+// Handle the root route and send the index.html file
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, '..', 'ECCM.html'));
+});
+
+app.put('/api/config', async (req, res) => {
+  try {
+    const filePath = path.resolve(__dirname, '../data/config.json');
+    await fs.writeFile(filePath, JSON.stringify(req.body, null, 2), 'utf8');
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to write config.json' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "config-server",
+  "version": "1.0.0",
+  "main": "app.js",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
I created the structure profile for the docker compose to use a simple nodejs container that will serve the ECCM.html file without needing to recreate it, and also edited that html file to have the config be a static file that can then be saved to the server to not loose any data (added save button to the top right).

Hope this helps!